### PR TITLE
fix: アプリがクラッシュするバグを修正

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -20,26 +20,6 @@
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
 
--dontwarn javax.lang.model.SourceVersion
--dontwarn javax.lang.model.element.Element
--dontwarn javax.lang.model.element.ElementKind
--dontwarn javax.lang.model.element.ElementVisitor
--dontwarn javax.lang.model.element.ExecutableElement
--dontwarn javax.lang.model.element.Modifier
--dontwarn javax.lang.model.element.Name
--dontwarn javax.lang.model.element.PackageElement
--dontwarn javax.lang.model.element.TypeElement
--dontwarn javax.lang.model.element.TypeParameterElement
--dontwarn javax.lang.model.element.VariableElement
--dontwarn javax.lang.model.type.ArrayType
--dontwarn javax.lang.model.type.DeclaredType
--dontwarn javax.lang.model.type.ExecutableType
--dontwarn javax.lang.model.type.TypeKind
--dontwarn javax.lang.model.type.TypeMirror
--dontwarn javax.lang.model.type.TypeVariable
--dontwarn javax.lang.model.type.TypeVisitor
--dontwarn javax.lang.model.util.ElementFilter
--dontwarn javax.lang.model.util.SimpleElementVisitor8
--dontwarn javax.lang.model.util.SimpleTypeVisitor7
--dontwarn javax.lang.model.util.SimpleTypeVisitor8
--dontwarn javax.lang.model.util.Types
+-dontwarn javax.lang.model.**
+-dontwarn kotlinx.serialization.**
+-dontwarn org.jetbrains.annotations.**

--- a/app/src/main/java/app/sanao1006/tsundoku/MainActivity.kt
+++ b/app/src/main/java/app/sanao1006/tsundoku/MainActivity.kt
@@ -7,12 +7,15 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import app.sanao1006.tsundoku.data.desiginsystem.TsundokuTheme
+import app.sanao1006.tsundoku.data.model.InputForCreateTsundoku
 import app.sanao1006.tsundoku.feature.create.TsundokuCreateScreen
 import app.sanao1006.tsundoku.feature.create.TsundokuCreateViewModel
 import app.sanao1006.tsundoku.feature.mainscreen.TsundokuScreen
@@ -52,8 +55,19 @@ private fun TsundokuApp(
             )
         }
         composable("create") {
+            val title by tsundokuCreateViewModel.title.collectAsState()
+            val description by tsundokuCreateViewModel.description.collectAsState()
+            val totalPage by tsundokuCreateViewModel.totalPage.collectAsState()
             TsundokuCreateScreen(
+                input = InputForCreateTsundoku(
+                    title = title,
+                    description = description,
+                    totalPage = totalPage,
+                ),
                 onBackButtonClick = { navController.popBackStack() },
+                onTitleValueChange = tsundokuCreateViewModel::onTitleValueChange,
+                onDescriptionValueChange = tsundokuCreateViewModel::onDescriptionValueChange,
+                onTotalPageValueChange = tsundokuCreateViewModel::onTotalPageValueChange,
                 onCreateButtonClick = {
                     tsundokuCreateViewModel.insertTsundoku()
                     navController.popBackStack()

--- a/app/src/main/java/app/sanao1006/tsundoku/data/model/InputForCreateTsundoku.kt
+++ b/app/src/main/java/app/sanao1006/tsundoku/data/model/InputForCreateTsundoku.kt
@@ -1,0 +1,7 @@
+package app.sanao1006.tsundoku.data.model
+
+data class InputForCreateTsundoku(
+    val title: String,
+    val description: String,
+    val totalPage: String,
+)

--- a/app/src/main/java/app/sanao1006/tsundoku/feature/create/TsundokuCreateScreen.kt
+++ b/app/src/main/java/app/sanao1006/tsundoku/feature/create/TsundokuCreateScreen.kt
@@ -19,8 +19,6 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Done
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
@@ -29,22 +27,22 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import app.sanao1006.tsundoku.data.model.InputForCreateTsundoku
 import io.sanao1006.tsundoku.R
 
 @OptIn(ExperimentalComposeUiApi::class)
 @Composable
 fun TsundokuCreateScreen(
+    input: InputForCreateTsundoku,
     onBackButtonClick: () -> Unit,
     onCreateButtonClick: () -> Unit,
+    onTitleValueChange: (String) -> Unit,
+    onDescriptionValueChange: (String) -> Unit,
+    onTotalPageValueChange: (String) -> Unit,
     modifier: Modifier = Modifier,
-    viewModel: TsundokuCreateViewModel = hiltViewModel()
 ) {
-    val title by viewModel.title.collectAsState()
-    val description by viewModel.description.collectAsState()
-    val totalPage by viewModel.totalPage.collectAsState()
-
     val keyboardController = LocalSoftwareKeyboardController.current
+
     Scaffold(
         topBar = {
             TopAppBar(
@@ -60,8 +58,8 @@ fun TsundokuCreateScreen(
         Box(modifier = modifier.padding(innerPadding)) {
             Column {
                 OutlinedTextField(
-                    value = title,
-                    onValueChange = { viewModel.onTitleValueChange(it) },
+                    value = input.title,
+                    onValueChange = onTitleValueChange,
                     label = { Text(stringResource(R.string.pref_create_tsundoku_title)) },
                     modifier = Modifier
                         .padding(16.dp)
@@ -69,8 +67,8 @@ fun TsundokuCreateScreen(
                 )
 
                 OutlinedTextField(
-                    value = description,
-                    onValueChange = { viewModel.onDescriptionValueChange(it) },
+                    value = input.description,
+                    onValueChange = onDescriptionValueChange,
                     label = { Text(stringResource(R.string.pref_create_tsundoku_description)) },
                     modifier = Modifier
                         .padding(16.dp)
@@ -78,8 +76,8 @@ fun TsundokuCreateScreen(
                 )
 
                 OutlinedTextField(
-                    value = totalPage,
-                    onValueChange = { viewModel.onTotalPageValueChange(it) },
+                    value = input.totalPage,
+                    onValueChange = onTotalPageValueChange,
                     label = { Text(stringResource(R.string.pref_create_tsundoku_page_count)) },
                     keyboardOptions = KeyboardOptions.Default.copy(
                         keyboardType = KeyboardType.Number,


### PR DESCRIPTION
ページ数を入力したときに入力がnullになりアプリがクラッシュしていた。
これはTsundokuCreateScreenの引数でhiltViewModel()をviewModelに代入していたためおきていた。
ついでに引数にon...系のコールバック関数を追加しすっきりさせた

Fixes  #9, #7