### PR TITLE
積読作成後ホーム画面に戻った時に追加したアイテムを即時反映させる

### DIFF
--- a/app/src/main/java/app/sanao1006/tsundoku/data/db/BookDao.kt
+++ b/app/src/main/java/app/sanao1006/tsundoku/data/db/BookDao.kt
@@ -5,11 +5,12 @@ import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import androidx.room.Update
+import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface BookDao {
     @Query("select * from books")
-    suspend fun getBooks(): List<BookEntity>
+    fun getBooks(): Flow<List<BookEntity>>
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertBook(book: BookEntity)

--- a/app/src/main/java/app/sanao1006/tsundoku/data/db/BookEntity.kt
+++ b/app/src/main/java/app/sanao1006/tsundoku/data/db/BookEntity.kt
@@ -3,6 +3,7 @@ package app.sanao1006.tsundoku.data.db
 import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.PrimaryKey
+import app.sanao1006.tsundoku.data.model.Book
 
 @Entity(tableName = "books")
 data class BookEntity(
@@ -21,4 +22,16 @@ data class BookEntity(
     val createdAt: String,
     @ColumnInfo(name = "updated_at")
     val updatedAt: String,
-)
+) {
+    fun toBook(): Book {
+        return Book(
+            id = this.id,
+            description = this.description ?: "",
+            title = this.title ?: "",
+            totalPage = this.totalPage,
+            nowPage = this.nowPage,
+            createAt = this.createdAt,
+            updatedAt = this.updatedAt
+        )
+    }
+}

--- a/app/src/main/java/app/sanao1006/tsundoku/data/di/TsundokuRepository.kt
+++ b/app/src/main/java/app/sanao1006/tsundoku/data/di/TsundokuRepository.kt
@@ -4,6 +4,8 @@ import app.sanao1006.tsundoku.data.db.BookDao
 import app.sanao1006.tsundoku.data.db.BookEntity
 import app.sanao1006.tsundoku.data.model.Book
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -13,21 +15,21 @@ class TsundokuRepository @Inject constructor(
     private val bookDao: BookDao,
     @IODispatcher private val ioDispatcher: CoroutineDispatcher
 ) {
-    suspend fun getBooks(): List<Book> {
-        return withContext(ioDispatcher) {
-            return@withContext bookDao.getBooks().map {
+    fun getBooks(): Flow<List<Book>> =
+        bookDao.getBooks().map {
+            it.map { bookEntity ->
                 Book(
-                    id = it.id,
-                    description = it.description ?: "",
-                    title = it.title ?: "",
-                    totalPage = it.totalPage,
-                    nowPage = it.nowPage,
-                    createAt = it.createdAt,
-                    updatedAt = it.updatedAt
+                    id = bookEntity.id,
+                    description = bookEntity.description ?: "",
+                    title = bookEntity.title ?: "",
+                    totalPage = bookEntity.totalPage,
+                    nowPage = bookEntity.nowPage,
+                    createAt = bookEntity.createdAt,
+                    updatedAt = bookEntity.updatedAt
                 )
             }
         }
-    }
+
     suspend fun insertBook(book: BookEntity) = withContext(ioDispatcher) {
         bookDao.insertBook(book = book)
     }

--- a/app/src/main/java/app/sanao1006/tsundoku/data/di/TsundokuRepository.kt
+++ b/app/src/main/java/app/sanao1006/tsundoku/data/di/TsundokuRepository.kt
@@ -15,20 +15,7 @@ class TsundokuRepository @Inject constructor(
     private val bookDao: BookDao,
     @IODispatcher private val ioDispatcher: CoroutineDispatcher
 ) {
-    fun getBooks(): Flow<List<Book>> =
-        bookDao.getBooks().map {
-            it.map { bookEntity ->
-                Book(
-                    id = bookEntity.id,
-                    description = bookEntity.description ?: "",
-                    title = bookEntity.title ?: "",
-                    totalPage = bookEntity.totalPage,
-                    nowPage = bookEntity.nowPage,
-                    createAt = bookEntity.createdAt,
-                    updatedAt = bookEntity.updatedAt
-                )
-            }
-        }
+    fun getBooks(): Flow<List<Book>> = bookDao.getBooks().map { it.map(BookEntity::toBook) }
 
     suspend fun insertBook(book: BookEntity) = withContext(ioDispatcher) {
         bookDao.insertBook(book = book)

--- a/app/src/main/java/app/sanao1006/tsundoku/feature/create/TsundokuCreateViewModel.kt
+++ b/app/src/main/java/app/sanao1006/tsundoku/feature/create/TsundokuCreateViewModel.kt
@@ -33,6 +33,13 @@ class TsundokuCreateViewModel @Inject constructor(
             createAt = getCurrentTime(),
             updatedAt = getCurrentTime(),
         )
+        clear()
+    }
+
+    private fun clear() {
+        _title.value = ""
+        _description.value = ""
+        _totalPage.value = ""
     }
 
     fun onTitleValueChange(title: String) {

--- a/app/src/main/java/app/sanao1006/tsundoku/feature/mainscreen/TsundokuScreenViewModel.kt
+++ b/app/src/main/java/app/sanao1006/tsundoku/feature/mainscreen/TsundokuScreenViewModel.kt
@@ -27,10 +27,12 @@ class TsundokuScreenViewModel @Inject constructor(
 
     private fun getBooks() {
         viewModelScope.launch {
-            _tsundokuState.value = TsundokuMainScreenState(
-                tsundokus = tsundokuRepository.getBooks(),
-                isLoading = false,
-            )
+            tsundokuRepository.getBooks().collect {
+                _tsundokuState.value = TsundokuMainScreenState(
+                    tsundokus = it,
+                    isLoading = false,
+                )
+            }
         }
     }
 }


### PR DESCRIPTION
積読作成後ホーム画面に戻った時に追加したアイテムがなかったため、FLowを用いて常に最新の状態が画面にレンダリングされるようにした

Fixed #5 